### PR TITLE
Bug - Anonymous sign in without db use

### DIFF
--- a/app/(root)/dashboard/page.tsx
+++ b/app/(root)/dashboard/page.tsx
@@ -1,118 +1,10 @@
 "use client";
 
 import { formatDuration } from "@/app/utils/general/formatters";
-import { createClient } from "@/app/utils/supabase/client";
 import Link from "next/link";
 import { useFileDetails } from "../../contexts/FileDetailsContext";
-import { showDirectoryPicker } from "file-system-access";
 import { useEffect } from "react";
-
-type VideoInfo = {
-  name: string;
-  thumbnail: string | null;
-  duration: number | null;
-  videoUrl: string;
-};
-
-type VideoInfoFromDbWithUrl = {
-  id: string;
-  user_id: string;
-  file_name: string;
-  thumbnail: string;
-  progress: number;
-  duration: number;
-  videoUrl: string;
-};
-
-type VideoInfoFromDb = Omit<VideoInfoFromDbWithUrl, "videoUrl">;
-
-async function processFile(file: File): Promise<{
-  name: string;
-  thumbnail: string | null;
-  duration: number | null;
-  videoUrl: string;
-}> {
-  const video = document.createElement("video");
-  video.src = URL.createObjectURL(file);
-  return new Promise((resolve) => {
-    video.onloadedmetadata = () => {
-      // Captures thumbnail at 1 second
-      video.currentTime = 1;
-    };
-
-    video.onseeked = () => {
-      const canvas = document.createElement("canvas");
-      const ctx = canvas.getContext("2d");
-
-      canvas.width = video.videoWidth;
-      canvas.height = video.videoHeight;
-
-      ctx?.drawImage(video, 0, 0, canvas.width, canvas.height);
-      const thumbnail = canvas.toDataURL("image/webp", 0.5);
-
-      resolve({
-        name: file.name,
-        thumbnail,
-        duration: video.duration,
-        videoUrl: video.src,
-      });
-    };
-    video.onerror = () => {
-      alert("Video rejected " + file.name);
-    };
-  });
-}
-
-async function fetchVideosInDb() {
-  const supabase = createClient();
-  const { data } = await supabase.from("videos").select();
-  return data;
-}
-
-async function upsertToDb(videoDetails: VideoInfo[]) {
-  const supabase = createClient();
-
-  const videosInDb = await fetchVideosInDb();
-  const matchingVideosFromDb: VideoInfoFromDbWithUrl[] = [];
-
-  const { data } = await supabase
-    .from("videos")
-    .upsert(
-      videoDetails.map((detail) => {
-        if (videosInDb !== null) {
-          let matchingVideo: VideoInfoFromDbWithUrl = videosInDb.find(
-            (video: VideoInfoFromDb) => video.id === detail.name
-          );
-          matchingVideo.videoUrl = detail.videoUrl;
-          matchingVideosFromDb.push(matchingVideo);
-          if (!matchingVideo) {
-            // Inserts into db as new entry
-            return {
-              id: detail.name,
-              file_name: detail.name,
-              thumbnail: detail.thumbnail,
-              progress: 0,
-              duration: detail.duration,
-            };
-          } else {
-            // Upserts to db without overwriting progress
-            return {
-              id: detail.name,
-              file_name: detail.name,
-              thumbnail: detail.thumbnail,
-              progress: matchingVideo.progress,
-              duration: detail.duration,
-            };
-          }
-        }
-      })
-    )
-    .select();
-
-  if (data) {
-  }
-  return matchingVideosFromDb;
-}
+import { HandleFolderSelectDb } from "@/app/components/ui/shared/HandleFolderSelectDb";
 
 export default function Dashboard() {
   const { fileDetails, setFileDetails } = useFileDetails();
@@ -127,52 +19,9 @@ export default function Dashboard() {
     iPhoneDetector();
   }, []);
 
-  const handleFolderSelect = async () => {
-    const showPicker = async () => {
-      try {
-        const handle = await showDirectoryPicker();
-        const details: {
-          name: string;
-          thumbnail: string | null;
-          duration: number | null;
-          videoUrl: string;
-        }[] = [];
-
-        async function getFiles(handle: FileSystemDirectoryHandle) {
-          const filesToProcess = [];
-          for await (const entry of handle.values()) {
-            if (entry.kind === "file") {
-              const file = await entry.getFile();
-              if (!file.type.startsWith("video/")) continue;
-              filesToProcess.push(file);
-            }
-          }
-          return filesToProcess;
-        }
-        const filesToProcess = await getFiles(handle);
-
-        await Promise.all(
-          filesToProcess.map(async (file) => {
-            details.push(await processFile(file));
-          })
-        );
-        const pickedVideos = await upsertToDb(details);
-        setFileDetails(pickedVideos);
-      } catch (error) {
-        console.error(error);
-        alert("This device may not support directory picking");
-      }
-    };
-    showPicker();
-  };
   return (
     <main>
-      <button
-        className="w-full rounded-md bg-sky-700 text-blue-100 text-xl p-4"
-        onClick={handleFolderSelect}
-      >
-        Scan a folder with the media you want to watch
-      </button>
+      <HandleFolderSelectDb setFileDetails={setFileDetails} />
 
       {fileDetails.length > 0 ? (
         <ul>

--- a/app/(root)/dashboard/page.tsx
+++ b/app/(root)/dashboard/page.tsx
@@ -4,8 +4,9 @@ import { formatDuration } from "@/app/utils/general/formatters";
 import Link from "next/link";
 import { useFileDetails } from "../../contexts/FileDetailsContext";
 import { useEffect, useState } from "react";
-import { HandleFolderSelectDb } from "@/app/components/ui/shared/HandleFolderSelectDb";
+import { HandleFolderSelect } from "@/app/components/ui/shared/HandleFolderSelect";
 import { createClient } from "@/app/utils/supabase/client";
+import { HandleFolderSelectNoDb } from "@/app/components/ui/shared/HandleFolderSelectNoDb";
 
 export default function Dashboard() {
   const { fileDetails, setFileDetails } = useFileDetails();
@@ -41,9 +42,9 @@ export default function Dashboard() {
   return (
     <main>
       {sessionWithEmail ? (
-        <HandleFolderSelectDb setFileDetails={setFileDetails} />
+        <HandleFolderSelect setFileDetails={setFileDetails} />
       ) : (
-        ""
+        <HandleFolderSelectNoDb setFileDetails={setFileDetails} />
       )}
 
       {fileDetails.length > 0 ? (

--- a/app/(root)/dashboard/page.tsx
+++ b/app/(root)/dashboard/page.tsx
@@ -3,11 +3,30 @@
 import { formatDuration } from "@/app/utils/general/formatters";
 import Link from "next/link";
 import { useFileDetails } from "../../contexts/FileDetailsContext";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { HandleFolderSelectDb } from "@/app/components/ui/shared/HandleFolderSelectDb";
+import { createClient } from "@/app/utils/supabase/client";
 
 export default function Dashboard() {
   const { fileDetails, setFileDetails } = useFileDetails();
+  const [sessionWithEmail, setSessionWithEmail] = useState(true);
+
+  useEffect(() => {
+    async function checkSession() {
+      const supabase = createClient();
+      const { data, error } = await supabase.auth.getSession();
+      if (error) {
+        console.log(error);
+      }
+
+      if (data.session?.user.email) {
+        setSessionWithEmail(true);
+      } else {
+        setSessionWithEmail(false);
+      }
+    }
+    checkSession();
+  }, []);
 
   useEffect(() => {
     function iPhoneDetector() {
@@ -21,7 +40,11 @@ export default function Dashboard() {
 
   return (
     <main>
-      <HandleFolderSelectDb setFileDetails={setFileDetails} />
+      {sessionWithEmail ? (
+        <HandleFolderSelectDb setFileDetails={setFileDetails} />
+      ) : (
+        ""
+      )}
 
       {fileDetails.length > 0 ? (
         <ul>

--- a/app/(root)/dashboard/videos/[name]/watch/page.tsx
+++ b/app/(root)/dashboard/videos/[name]/watch/page.tsx
@@ -2,7 +2,7 @@
 
 import { notFound, usePathname, useSearchParams } from "next/navigation";
 import Player from "next-video/player";
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import { createClient } from "@/app/utils/supabase/client";
 
 // import { Metadata } from "next";
@@ -11,46 +11,18 @@ import { createClient } from "@/app/utils/supabase/client";
 //   title: "Watch",
 // };
 
-type videoInfoFromDb = {
-  id: string;
-  user_id: string;
-  file_name: string;
-  thumbnail: string;
-  progress: number;
-  duration: number;
-};
-
 export default function Watch() {
   const supabase = createClient();
   const searchParams = useSearchParams();
   const videoUrl = searchParams.get("videoUrl");
   const progress = searchParams.get("progress");
   const videoRef = useRef<HTMLVideoElement | null>(null);
-  const [videoDbInfo, setVideoDbInfo] = useState<videoInfoFromDb>();
-  const [loading, setLoading] = useState(true);
   const pathname = usePathname();
   const videoName = pathname.split("/")[3];
 
   if (!videoUrl) {
     notFound();
   }
-
-  useLayoutEffect(() => {
-    async function fetchVideoInfo() {
-      const { data, error } = await supabase
-        .from("videos")
-        .select()
-        .eq("id", videoName);
-      if (data && data.length > 0) {
-        setVideoDbInfo(data[0]);
-        setLoading(false);
-      } else {
-        console.error("Error fetching video data from db: ", error);
-      }
-    }
-
-    fetchVideoInfo();
-  }, [supabase, videoName]);
 
   useEffect(() => {
     async function updateProgress() {
@@ -64,33 +36,14 @@ export default function Watch() {
         }
       }
     }
-
     const intervalId = setInterval(updateProgress, 5000);
 
     return () => clearInterval(intervalId);
   }, [supabase, videoName]);
 
-  useEffect(() => {
-    // For setting the playback location of the video loaded.
-    // if (videoDbInfo && videoRef.current) {
-    //   const video = videoRef.current;
-    //   const handleLoadedMetadata = () => {
-    //     video.currentTime = videoDbInfo!.progress;
-    //   };
-    //   if (video.readyState >= 1) {
-    //     video.currentTime = progress;
-    //   } else {
-    //     video.addEventListener("loadedmetadata", handleLoadedMetadata);
-    //   }
-    //   return () => {
-    //     video.removeEventListener("loadedmetadata", handleLoadedMetadata);
-    //   };
-    // }
-  }, [videoRef]);
-
   return (
     <main>
-      {!loading && videoUrl && videoDbInfo ? (
+      {videoUrl ? (
         <>
           <Player
             style={{ display: "grid", width: "100%" }}

--- a/app/components/ui/shared/HandleFolderSelect.tsx
+++ b/app/components/ui/shared/HandleFolderSelect.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { createClient } from "@/app/utils/supabase/client";
+import { showDirectoryPicker } from "file-system-access";
+import { Dispatch, SetStateAction } from "react";
+
+type VideoInfo = {
+  name: string;
+  thumbnail: string | null;
+  duration: number | null;
+  videoUrl: string;
+};
+
+type VideoInfoFromDbWithUrl = {
+  id: string;
+  user_id: string;
+  file_name: string;
+  thumbnail: string;
+  progress: number;
+  duration: number;
+  videoUrl: string;
+};
+
+type VideoInfoFromDb = Omit<VideoInfoFromDbWithUrl, "videoUrl">;
+
+async function fetchVideosInDb() {
+  const supabase = createClient();
+  const { data } = await supabase.from("videos").select();
+  return data;
+}
+
+async function upsertToDb(videoDetails: VideoInfo[]) {
+  const supabase = createClient();
+
+  const videosInDb = await fetchVideosInDb();
+  const matchingVideosFromDb: VideoInfoFromDbWithUrl[] = [];
+
+  const { data } = await supabase
+    .from("videos")
+    .upsert(
+      videoDetails.map((detail) => {
+        if (videosInDb !== null) {
+          let matchingVideo: VideoInfoFromDbWithUrl = videosInDb.find(
+            (video: VideoInfoFromDb) => video.id === detail.name
+          );
+          matchingVideo.videoUrl = detail.videoUrl;
+          matchingVideosFromDb.push(matchingVideo);
+          if (!matchingVideo) {
+            // Inserts into db as new entry
+            return {
+              id: detail.name,
+              file_name: detail.name,
+              thumbnail: detail.thumbnail,
+              progress: 0,
+              duration: detail.duration,
+            };
+          } else {
+            // Upserts to db without overwriting progress
+            return {
+              id: detail.name,
+              file_name: detail.name,
+              thumbnail: detail.thumbnail,
+              progress: matchingVideo.progress,
+              duration: detail.duration,
+            };
+          }
+        }
+      })
+    )
+    .select();
+
+  if (data) {
+  }
+  return matchingVideosFromDb;
+}
+
+async function processFile(file: File): Promise<{
+  name: string;
+  thumbnail: string | null;
+  duration: number | null;
+  videoUrl: string;
+}> {
+  const video = document.createElement("video");
+  video.src = URL.createObjectURL(file);
+  return new Promise((resolve) => {
+    video.onloadedmetadata = () => {
+      // Captures thumbnail at 1 second
+      video.currentTime = 1;
+    };
+
+    video.onseeked = () => {
+      const canvas = document.createElement("canvas");
+      const ctx = canvas.getContext("2d");
+
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+
+      ctx?.drawImage(video, 0, 0, canvas.width, canvas.height);
+      const thumbnail = canvas.toDataURL("image/webp", 0.5);
+
+      resolve({
+        name: file.name,
+        thumbnail,
+        duration: video.duration,
+        videoUrl: video.src,
+      });
+    };
+    video.onerror = () => {
+      alert("Video rejected " + file.name);
+    };
+  });
+}
+
+export function HandleFolderSelect({
+  setFileDetails,
+}: {
+  setFileDetails: Dispatch<SetStateAction<VideoInfoFromDbWithUrl[]>>;
+}) {
+  async function handleShowPicker() {
+    async function showPicker() {
+      try {
+        const handle = await showDirectoryPicker();
+        const details: {
+          name: string;
+          thumbnail: string | null;
+          duration: number | null;
+          videoUrl: string;
+        }[] = [];
+
+        async function getFiles(handle: FileSystemDirectoryHandle) {
+          const filesToProcess = [];
+          for await (const entry of handle.values()) {
+            if (entry.kind === "file") {
+              const file = await entry.getFile();
+              if (!file.type.startsWith("video/")) continue;
+              filesToProcess.push(file);
+            }
+          }
+          return filesToProcess;
+        }
+        const filesToProcess = await getFiles(handle);
+
+        await Promise.all(
+          filesToProcess.map(async (file) => {
+            details.push(await processFile(file));
+          })
+        );
+        const pickedVideos = await upsertToDb(details);
+        setFileDetails(pickedVideos);
+      } catch (error) {
+        console.error(error);
+        alert("This device may not support directory picking");
+      }
+    }
+    showPicker();
+  }
+  return (
+    <>
+      <button
+        className="w-full rounded-md bg-sky-700 text-blue-100 text-xl p-4"
+        onClick={handleShowPicker}
+      >
+        Scan a folder with the media you want to watch
+      </button>
+    </>
+  );
+}

--- a/app/components/ui/shared/HandleFolderSelectDb.tsx
+++ b/app/components/ui/shared/HandleFolderSelectDb.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { createClient } from "@/app/utils/supabase/client";
+import { showDirectoryPicker } from "file-system-access";
+import { Dispatch, SetStateAction } from "react";
+
+type VideoInfo = {
+  name: string;
+  thumbnail: string | null;
+  duration: number | null;
+  videoUrl: string;
+};
+
+type VideoInfoFromDbWithUrl = {
+  id: string;
+  user_id: string;
+  file_name: string;
+  thumbnail: string;
+  progress: number;
+  duration: number;
+  videoUrl: string;
+};
+
+type VideoInfoFromDb = Omit<VideoInfoFromDbWithUrl, "videoUrl">;
+
+async function fetchVideosInDb() {
+  const supabase = createClient();
+  const { data } = await supabase.from("videos").select();
+  return data;
+}
+
+async function upsertToDb(videoDetails: VideoInfo[]) {
+  const supabase = createClient();
+
+  const videosInDb = await fetchVideosInDb();
+  const matchingVideosFromDb: VideoInfoFromDbWithUrl[] = [];
+
+  const { data } = await supabase
+    .from("videos")
+    .upsert(
+      videoDetails.map((detail) => {
+        if (videosInDb !== null) {
+          let matchingVideo: VideoInfoFromDbWithUrl = videosInDb.find(
+            (video: VideoInfoFromDb) => video.id === detail.name
+          );
+          matchingVideo.videoUrl = detail.videoUrl;
+          matchingVideosFromDb.push(matchingVideo);
+          if (!matchingVideo) {
+            // Inserts into db as new entry
+            return {
+              id: detail.name,
+              file_name: detail.name,
+              thumbnail: detail.thumbnail,
+              progress: 0,
+              duration: detail.duration,
+            };
+          } else {
+            // Upserts to db without overwriting progress
+            return {
+              id: detail.name,
+              file_name: detail.name,
+              thumbnail: detail.thumbnail,
+              progress: matchingVideo.progress,
+              duration: detail.duration,
+            };
+          }
+        }
+      })
+    )
+    .select();
+
+  if (data) {
+  }
+  return matchingVideosFromDb;
+}
+
+async function processFile(file: File): Promise<{
+  name: string;
+  thumbnail: string | null;
+  duration: number | null;
+  videoUrl: string;
+}> {
+  const video = document.createElement("video");
+  video.src = URL.createObjectURL(file);
+  return new Promise((resolve) => {
+    video.onloadedmetadata = () => {
+      // Captures thumbnail at 1 second
+      video.currentTime = 1;
+    };
+
+    video.onseeked = () => {
+      const canvas = document.createElement("canvas");
+      const ctx = canvas.getContext("2d");
+
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+
+      ctx?.drawImage(video, 0, 0, canvas.width, canvas.height);
+      const thumbnail = canvas.toDataURL("image/webp", 0.5);
+
+      resolve({
+        name: file.name,
+        thumbnail,
+        duration: video.duration,
+        videoUrl: video.src,
+      });
+    };
+    video.onerror = () => {
+      alert("Video rejected " + file.name);
+    };
+  });
+}
+
+export function HandleFolderSelectDb({
+  setFileDetails,
+}: {
+  setFileDetails: Dispatch<SetStateAction<VideoInfoFromDbWithUrl[]>>;
+}) {
+  async function handleShowPicker() {
+    async function showPicker() {
+      try {
+        const handle = await showDirectoryPicker();
+        const details: {
+          name: string;
+          thumbnail: string | null;
+          duration: number | null;
+          videoUrl: string;
+        }[] = [];
+
+        async function getFiles(handle: FileSystemDirectoryHandle) {
+          const filesToProcess = [];
+          for await (const entry of handle.values()) {
+            if (entry.kind === "file") {
+              const file = await entry.getFile();
+              if (!file.type.startsWith("video/")) continue;
+              filesToProcess.push(file);
+            }
+          }
+          return filesToProcess;
+        }
+        const filesToProcess = await getFiles(handle);
+
+        await Promise.all(
+          filesToProcess.map(async (file) => {
+            details.push(await processFile(file));
+          })
+        );
+        const pickedVideos = await upsertToDb(details);
+        setFileDetails(pickedVideos);
+      } catch (error) {
+        console.error(error);
+        alert("This device may not support directory picking");
+      }
+    }
+    showPicker();
+  }
+  return (
+    <>
+      <button
+        className="w-full rounded-md bg-sky-700 text-blue-100 text-xl p-4"
+        onClick={handleShowPicker}
+      >
+        Scan a folder with the media you want to watch
+      </button>
+    </>
+  );
+}


### PR DESCRIPTION
##Description

- Anonymous users can load videos and watch them. Progress is not saved.
- Componentised the folder picker, created a version of the folder picker that doesn't require a database call.
- Users who are signed in will have Progress passed from the dashboard to the watch page, videos load without waiting for a db call.
