### PR TITLE
Bug - Video rejects on ipad

### DIFF
--- a/app/(root)/dashboard/layout.tsx
+++ b/app/(root)/dashboard/layout.tsx
@@ -12,7 +12,7 @@ import SideNav from "../../components/ui/dashboard/Sidenav";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex flex-col-reverse flex-grow w-full h-screen md:flex-row md:overflow-hidden">
+    <div className="flex flex-col-reverse flex-grow w-full h-svh md:flex-row md:overflow-hidden">
       <SideNav />
       <div className="h-lvh overflow-x-hidden flex-grow p-6 md:p-12">
         {children}

--- a/app/(root)/dashboard/page.tsx
+++ b/app/(root)/dashboard/page.tsx
@@ -86,7 +86,7 @@ export default function Dashboard() {
                       className="w-[102px] h-[72px] object-cover rounded-tl-lg rounded-bl-lg"
                     />
                   ) : null}
-                  <p className="text-black truncate ml-2 lg:ml-4">
+                  <p className="text-black truncate ml-2 mr-1 lg:ml-4">
                     {file.file_name}
                   </p>
                   {file.duration ? (

--- a/app/components/ui/dashboard/Sidenav.tsx
+++ b/app/components/ui/dashboard/Sidenav.tsx
@@ -5,7 +5,7 @@ import { ThemeSwitch } from "@/app/components/ui/shared/DarkModeToggle";
 
 export default async function SideNav() {
   return (
-    <div className="flex h-16 flex-shrink-0 md:h-full md:flex-col md:py-4 md:px-2 md:w-44">
+    <div className="flex h-16 flex-shrink-0 md:h-svh md:flex-col md:py-4 md:px-2 md:w-44">
       <Link
         className="flex w-28 md:w-full md:h-20 rounded-lg bg-blue-200"
         href="/dashboard"

--- a/app/components/ui/shared/HandleFolderSelect.tsx
+++ b/app/components/ui/shared/HandleFolderSelect.tsx
@@ -133,9 +133,12 @@ async function processFile(file: File): Promise<{
         videoUrl: video.src,
       });
     };
-    video.onerror = () => {
-      alert("Video rejected " + file.name);
-    };
+    video.addEventListener("error", function (event) {
+      alert("Ahh:" + event.error);
+    });
+    // video.onerror = () => {
+    //   alert("Video rejected " + file.name);
+    // };
   });
 }
 

--- a/app/components/ui/shared/HandleFolderSelect.tsx
+++ b/app/components/ui/shared/HandleFolderSelect.tsx
@@ -134,11 +134,14 @@ async function processFile(file: File): Promise<{
       });
     };
     video.addEventListener("error", function (event) {
-      alert("Ahh:" + event.error);
+      alert(
+        `An error has occurred on file ${file.name.substring(
+          0,
+          -4
+        )}... - Please check the console for details`
+      );
+      console.log(event.error);
     });
-    // video.onerror = () => {
-    //   alert("Video rejected " + file.name);
-    // };
   });
 }
 


### PR DESCRIPTION
##Description

- iPad does not raise false error alerts on videos that eventually load.
- Replaced video.onerror = () => with an event listener for 'error'.